### PR TITLE
Added color type

### DIFF
--- a/src/api/CustomerApi.ts
+++ b/src/api/CustomerApi.ts
@@ -2,9 +2,11 @@ import { callAPI } from './apiUtilities';
 
 export const choosableColors = ['red', 'pink', 'rebeccapurple', 'grey'];
 
+export type Color = 'red' | 'pink' | 'rebeccapurple' | 'grey'
+
 export interface Customer {
   name: string;
-  color: string; // TODO: Create a new Color type, I only want the "choosableColors" above to be permitted on Customers
+  color: Color;
   age: number;
   isCool: boolean;
 }


### PR DESCRIPTION
1. Fix the <i>color</i> variable within the Customer interface found [here](/src/api/CustomerApi.ts#L7) by creating a "Color" type, that only allows the 4 choosable colors. You will have to follow the type around to fix associated components found: [here](src/pages/Landing/index.tsx#L98) and [here](src/components/ColoredTd.tsx#L4)